### PR TITLE
전체 게시글 및 전체 페이지 목록 페이징 구현 #87 DAILYLIFE2-33

### DIFF
--- a/src/main/java/com/dailylife/domain/board/controller/BoardController.java
+++ b/src/main/java/com/dailylife/domain/board/controller/BoardController.java
@@ -41,9 +41,10 @@ public class BoardController {
 
         return ResponseEntity.ok(boardService.delete(boardNum));
     }
-    @ApiOperation(value = "페이징 게시글 가져오기", notes = "한 페이지 당 15개 게시글 가져옴, pg(현재 페이지)만 넘겨주시면 됩니다")
-    @GetMapping("/getBoard/{pg}")
-    public ResponseEntity<List<BoardCreateAndGetResponse>> list(@PathVariable("pg")int pg, BoardPagination pagination) {
+    @ApiOperation(value = "페이징 게시글 가져오기", notes = "한 페이지 당 15개 게시글 가져옴, queryString 사용하여 pg(몇 페이지)는 필수로 넘겨주시고 query(검색어)는 있으면 채워서 보내주시면 됩니다(선택)")
+    @GetMapping("/getBoard")
+    public ResponseEntity<List<BoardCreateAndGetResponse>> list(@RequestParam(value = "pg", defaultValue = "1") int pg,@RequestParam(value = "keyword",defaultValue = "") String keyword, BoardPagination pagination) {
+        System.out.println(pagination.getKeyword());
         return ResponseEntity.ok(boardService.getPage(pagination));
     }
 

--- a/src/main/java/com/dailylife/domain/board/dto/BoardPagination.java
+++ b/src/main/java/com/dailylife/domain/board/dto/BoardPagination.java
@@ -6,6 +6,7 @@ import lombok.Data;
 public class BoardPagination {
         int pg = 1;        // 현재 페이지
         int sz = 15;       // 페이지 당 레코드 수
+        String keyword;
 
         int recordCount;   // 전체 레코드 수
 

--- a/src/main/java/com/dailylife/domain/board/repository/BoardPaginationRepository.java
+++ b/src/main/java/com/dailylife/domain/board/repository/BoardPaginationRepository.java
@@ -4,14 +4,29 @@ import com.dailylife.domain.board.dto.BoardPagination;
 import com.dailylife.domain.board.entity.Board;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface BoardPaginationRepository extends JpaRepository<Board, Long> {
     public default List<Board> findAll(BoardPagination pagination) {
+        System.out.println(pagination.getKeyword());
+        if(pagination.getKeyword()!=null){
+            return findTitle(pagination);
+        }
         Page<Board> page = this.findAll(PageRequest.of(pagination.getPg() - 1, pagination.getSz(),
+                Sort.Direction.DESC, "boardNum"));
+        pagination.setRecordCount((int)page.getTotalElements());
+        return page.getContent();
+    }
+
+    Page<Board> findByTitleContaining(String keyword, Pageable pageable);
+
+    public default List<Board> findTitle(BoardPagination pagination) {
+        Page<Board> page = this.findByTitleContaining(pagination.getKeyword(),PageRequest.of(pagination.getPg() - 1, pagination.getSz(),
                 Sort.Direction.DESC, "boardNum"));
         pagination.setRecordCount((int)page.getTotalElements());
         return page.getContent();

--- a/src/main/java/com/dailylife/domain/board/service/BoardService.java
+++ b/src/main/java/com/dailylife/domain/board/service/BoardService.java
@@ -18,4 +18,6 @@ public interface BoardService {
 
     int getBoardCount();
 
+    List<Board> TitleList(BoardPagination pagination);
+
 }

--- a/src/main/java/com/dailylife/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/dailylife/domain/board/service/BoardServiceImpl.java
@@ -95,4 +95,9 @@ public class BoardServiceImpl implements BoardService{
     public int getBoardCount() {
         return boardRepository.countAllByBoardNum();
     }
+
+    @Override
+    public List<Board> TitleList(BoardPagination pagination) {
+        return paginationRepository.findTitle(pagination);
+    }
 }


### PR DESCRIPTION
api/board/getBoard?pg=몇 페이지&keyword=”검색어(미 입력시 null)” 해당 경로로 접근 시
pg(페이지목록)은 default 1페이지로 설정되며, keyword(검색어)를 별도로 입력하지 않았으면 전체 게시글을 페이징 해주고, keyword가 입력되어 쿼리스트링으로 넘어오면 해당 키워드가 포함 된 내용으로만 페이징 처리

 *(현재는 게시글 제목으로 검색하게 구현하였으나 해쉬태그등으로 변경 예정)